### PR TITLE
SQ2-175 - Add 'includes' operator for Sablon array comparisons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sablon (0.0.24)
+    sablon (0.0.25)
       nokogiri (>= 1.10.0)
       rubyzip (>= 1.1)
 

--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -56,9 +56,12 @@ module Sablon
         left = parse_operand(left_operand, env)
         right = parse_operand(right_operand, env)
 
-        # Handle single-element arrays
-        left = left.first if left.is_a?(Array) && left.size == 1
-        right = right.first if right.is_a?(Array) && right.size == 1
+        # Handle single-element arrays.
+        # This is necessary for dropdowns with multi-select disabled, because they still return arrays.
+        unless operator == 'includes'
+          left = left.first if left.is_a?(Array) && left.size == 1
+          right = right.first if right.is_a?(Array) && right.size == 1
+        end
 
         if build_operation(operator, left, right).call
           block.replace(block.process(env).reverse)

--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -2,6 +2,8 @@
 
 module Sablon
   module Statement
+    ARRAY_OPERATIONS = %w[includes excludes].freeze
+
     Insertion = Struct.new(:expr, :field) do
       def evaluate(env)
         if (content = expr.evaluate(env.context))
@@ -58,7 +60,7 @@ module Sablon
 
         # Handle single-element arrays.
         # This is necessary for dropdowns with multi-select disabled, because they still return arrays.
-        unless operator == 'includes'
+        unless ARRAY_OPERATIONS.include?(operator)
           left = left.first if left.is_a?(Array) && left.size == 1
           right = right.first if right.is_a?(Array) && right.size == 1
         end
@@ -82,8 +84,10 @@ module Sablon
           '>' => -> { left > right },
           '<=' => -> { left <= right },
           '>=' => -> { left >= right },
-          'includes' => -> { left.is_a?(Array) && left.include?(right) }
+          'includes' => -> { left.is_a?(Array) && left.include?(right) },
+          'excludes' => -> { left.is_a?(Array) && !left.include?(right) }
         }
+
         raise ArgumentError, "Unknown operator: #{operator}" unless operations.key?(operator)
 
         operations[operator]

--- a/lib/sablon/operations.rb
+++ b/lib/sablon/operations.rb
@@ -78,7 +78,8 @@ module Sablon
           '<' => -> { left < right },
           '>' => -> { left > right },
           '<=' => -> { left <= right },
-          '>=' => -> { left >= right }
+          '>=' => -> { left >= right },
+          'includes' => -> { left.is_a?(Array) && left.include?(right) }
         }
         raise ArgumentError, "Unknown operator: #{operator}" unless operations.key?(operator)
 

--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -205,7 +205,7 @@ module Sablon
           when /^@([^ ]+):start/
             block = consume_block("@#{::Regexp.last_match(1)}:end")
             Statement::Image.new(Expression.parse(::Regexp.last_match(1)), block)
-          when /([^ ]+):if\s*(==|!=|<=|>=|<|>|includes)\s*(['"].+?['"]|[\w.]+)$/
+          when /([^ ]+):if\s*(==|!=|<=|>=|<|>|includes|excludes)\s*(['"].+?['"]|[\w.]+)$/
             block = consume_block("#{::Regexp.last_match(1)}:endIf")
             Statement::ExpressiveCondition.new(
               ::Regexp.last_match(1), ::Regexp.last_match(2), ::Regexp.last_match(3), block

--- a/lib/sablon/processor/document.rb
+++ b/lib/sablon/processor/document.rb
@@ -205,7 +205,7 @@ module Sablon
           when /^@([^ ]+):start/
             block = consume_block("@#{::Regexp.last_match(1)}:end")
             Statement::Image.new(Expression.parse(::Regexp.last_match(1)), block)
-          when /([^ ]+):if\s*(==|!=|<=|>=|<|>)\s*(['"].+?['"]|[\w.]+)$/
+          when /([^ ]+):if\s*(==|!=|<=|>=|<|>|includes)\s*(['"].+?['"]|[\w.]+)$/
             block = consume_block("#{::Regexp.last_match(1)}:endIf")
             Statement::ExpressiveCondition.new(
               ::Regexp.last_match(1), ::Regexp.last_match(2), ::Regexp.last_match(3), block

--- a/lib/sablon/version.rb
+++ b/lib/sablon/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sablon
-  VERSION = '0.0.24'
+  VERSION = '0.0.25'
 end

--- a/test/fixtures/xml/conditional_with_expression_and_array_input.xml
+++ b/test/fixtures/xml/conditional_with_expression_and_array_input.xml
@@ -28,6 +28,31 @@
     </w:r>
   </w:fldSimple>
   <w:r>
+    <w:t xml:space="preserve"> </w:t>
+  </w:r>
+  <w:fldSimple w:instr=" MERGEFIELD middle_names:if excludes 'Johnathon' \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr>
+        <w:noProof />
+      </w:rPr>
+      <w:t>«middle_name:if»</w:t>
+    </w:r>
+  </w:fldSimple>
+  <w:r>
+    <w:t>NotJohnathon</w:t>
+  </w:r>
+  <w:r>
+    <w:t xml:space="preserve"> </w:t>
+  </w:r>
+  <w:fldSimple w:instr=" MERGEFIELD middle_names:endIf \* MERGEFORMAT ">
+    <w:r>
+      <w:rPr>
+        <w:noProof />
+      </w:rPr>
+      <w:t>«middle_name:endIf»</w:t>
+    </w:r>
+  </w:fldSimple>
+  <w:r>
     <w:t>Hall</w:t>
   </w:r>
 </w:p>

--- a/test/processor/document_test.rb
+++ b/test/processor/document_test.rb
@@ -385,7 +385,7 @@ class ProcessorDocumentTest < Sablon::TestCase
     result = process(snippet('conditional_with_expression_and_array_input'),
                      { 'first_name' => 'Anthony', 'middle_names' => ['Michael'], 'last_name' => 'Hall' })
 
-    assert_equal 'Anthony Michael Hall', text(result)
+    assert_equal 'Anthony Michael NotJohnathon Hall', text(result)
   end
 
   def test_nested_conditional_expression


### PR DESCRIPTION
This PR adds a pair of new operators, `includes` and `excludes`, to the expressive if-statements operation. It allows for inclusion/exclusion checks on array variables passed to Sablon via the context hash. The `includes` operator checks if an array, `a`, contains a value, `b`, such that:

```
a:if includes b
```

evaluates to `true`, where `a = ['Angus', 'Michael']`, and `b` equals `'Angus'`. The `excludes` operator returns the inverse.