### PR TITLE
SQ3-410 - fix: enable WordML content reusability with current_fragment helper

### DIFF
--- a/lib/sablon/content.rb
+++ b/lib/sablon/content.rb
@@ -74,6 +74,10 @@ module Sablon
       def self.wraps?(value); false end
 
       def initialize(value)
+        # Store as DocumentFragment to preserve namespace handling and XML structure.
+        # Note: Nodes from a fragment can only be added to a document once, as
+        # Nokogiri's add_next_sibling() moves nodes rather than copying them.
+        # The current_fragment() method handles creating fresh nodes when needed.
         super Nokogiri::XML.fragment(value)
       end
 
@@ -106,9 +110,27 @@ module Sablon
 
       private
 
+      # Returns a fresh DocumentFragment with new node instances.
+      #
+      # This method is critical for reusability: since Nokogiri's add_next_sibling()
+      # moves nodes (changing their parent), nodes from the original @xml fragment
+      # can only be inserted once. By re-parsing xml.to_xml(save_with: 0), we create
+      # brand new node instances that can be freely added to the document without
+      # affecting future insertions of the same WordML content.
+      #
+      # This allows the same WordML object to be used multiple times (e.g., inserting
+      # the same table into multiple documents), which is essential for template
+      # processing where content objects are often reused.
+      #
+      # The save_with: 0 option disables pretty-printing to avoid introducing
+      # unwanted whitespace/newlines during serialization.
+      def current_fragment
+        Nokogiri::XML.fragment(self.xml.to_xml(save_with: 0))
+      end
+
       # Returns `true` if all of the xml nodes to be inserted are
       def all_inline?
-        (xml.children.map(&:node_name) - inline_tags).empty?
+        (current_fragment.children.map(&:node_name) - inline_tags).empty?
       end
 
       # Array of tags allowed to be a child of the w:p XML tag as defined
@@ -128,18 +150,22 @@ module Sablon
 
       # Adds the XML to be inserted in the document as siblings to the
       # node passed in. Run properties are merged here because of namespace
-      # issues when working with a document fragment
+      # issues when working with a document fragment.
       def add_siblings_to(node, rpr_tag = nil)
-        # Since Nokogiri 1.11.0 adding siblings is only possible for nodes
-        # with a parent because the parent is used as the context node for
-        # parsing markup.
-        if !node.parent.nil?
-          xml.children.reverse.each do |child|
-            node.add_next_sibling child
-            # merge properties
-            next unless rpr_tag
-            merge_rpr_tags(child, rpr_tag.children)
-          end
+        # Guard: Since Nokogiri 1.11.0, adding siblings requires the node to have
+        # a parent (used as context for parsing). If the node was already removed
+        # from the document tree, silently skip insertion.
+        return if node.parent.nil?
+
+        # Use current_fragment to get fresh node instances. This is essential for
+        # reusability: nodes can only be added once since add_next_sibling() moves
+        # them rather than copying. Fresh nodes allow the same WordML content to be
+        # inserted multiple times.
+        current_fragment.children.reverse.each do |child|
+          node.add_next_sibling child
+          # merge properties
+          next unless rpr_tag
+          merge_rpr_tags(child, rpr_tag.children)
         end
       end
 

--- a/test/content_test.rb
+++ b/test/content_test.rb
@@ -237,6 +237,43 @@ class ContentWordMLTest < Sablon::TestCase
 
     assert_xml_equal output, @document
   end
+
+  def test_inserts_table_word_ml_into_the_document
+    @word_ml = <<-XML.gsub(/^\s+|\n/, '')
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>Cell 1</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>Cell 2</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+    XML
+
+    # Create content object ONCE
+    content = Sablon.content(:word_ml, @word_ml)
+
+    # First insertion
+    content.append_to @paragraph, @node, @env
+
+    output = <<-XML.gsub(/^\s+|\n/, '')
+      <w:tbl>
+        <w:tr>
+          <w:tc><w:p><w:r><w:t>Cell 1</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>Cell 2</w:t></w:r></w:p></w:tc>
+        </w:tr>
+      </w:tbl>
+      <w:p>AFTER</w:p>
+    XML
+
+    assert_xml_equal output, @document
+
+    # Second insertion with SAME content object - tests reusability
+    @document = Nokogiri::XML(doc_wrapper(@template_text))
+    @paragraph = @document.xpath('//w:p').first
+    @node = @paragraph.xpath('.//w:r').first.at_xpath('./w:t')
+
+    content.append_to @paragraph, @node, @env
+    assert_xml_equal output, @document
+  end
 end
 
 class ContentImageTest < Sablon::TestCase


### PR DESCRIPTION
### Background

Payment plan tables were disappearing from generated PDFs. Troubleshooting revealed the root cause was in Sablon [PR #84](https://github.com/senny/sablon/pull/84) (2018), which changed WordML to store parsed DocumentFragment objects instead of strings.

The problem: Nokogiri's `add_next_sibling` moves nodes rather than copying them. When a WordML object was used once, its nodes were moved from `xml.children` into the document. On subsequent reuse, `xml.children` was empty, causing content to silently disappear.

The bug existed since Sablon [PR #84](https://github.com/senny/sablon/pull/84) (Jan 2018) but went unnoticed because most code creates fresh WordML objects for each use. Payment plans are the possible unique case that truly reused the same object (_to check other scenarios as well_).

### Changes

Added `current_fragment` helper method that creates fresh node instances on demand by re-parsing XML. This can be seen as not performant at first glance, but they are parsed only when needed, so I think we won't face performance issues here.

Also added a new test case that reuses the same table content twice to prevent regression.